### PR TITLE
DRAFT: Experiment to change from lettered parts to numbered parts to match respec structure. 

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
 				shortName: "atag",
 				group: "atag",
 				latestVersion: "https://www.w3.org/TR/atag/",
+				tocIntroductory: true,
 				editors: [
 					{
 						name: "Jan Richards",
@@ -46,9 +47,9 @@
 			<p>
 				The Authoring Tool Accessibility Guidelines (ATAG) 2.0 provides
 				guidelines for designing web content authoring tools that are both more
-				accessible to authors with disabilities (Part A) and designed to enable,
+				accessible to authors with disabilities (Part 1) and designed to enable,
 				support, and promote the production of more accessible web content by
-				all authors (Part B). See
+				all authors (Part 2). See
 				<a href="https://www.w3.org/WAI/standards-guidelines/atag/"
 					>Authoring Tool Accessibility Guidelines (ATAG) Overview</a
 				>
@@ -59,7 +60,7 @@
 
 		<section id="sotd"></section>
 
-	<section id="intro" class="informative">
+		<section id="intro" class="informative introductory">
 			<h2>Introduction</h2>
 
 			<p>
@@ -80,13 +81,13 @@
 				<li>
 					[=authors=] of [=web content=], whose needs are met by ensuring that
 					[=authoring tool user interfaces=] are more accessible (addressed by
-					<a href="#part_a">Part A of the Guidelines</a>), and
+					<a href="#part_1">Part 1 of the Guidelines</a>), and
 				</li>
 				<li>
 					[=end users=] of web content, whose needs are met by ensuring that all
 					authors are enabled, supported, and guided by the authoring tools that
 					they use toward producing [=accessible web content (WCAG)=] (addressed
-					by <a href="#part_b">Part B of the Guidelines</a>).
+					by <a href="#part_2">Part 2 of the Guidelines</a>).
 				</li>
 			</ul>
 
@@ -169,19 +170,19 @@
 					<li>
 						<strong>Parts:</strong> ATAG 2.0 is divided into two parts, each
 						reflecting a key aspect of accessibility with respect to authoring
-						tools. <a href="#part_a">Part A</a> relates to the accessibility of
+						tools. <a href="#part_1">Part 1</a> relates to the accessibility of
 						[=authoring tool user interfaces=] to authors with disabilities.
-						<a href="#part_b">Part B</a> relates to support by authoring tools
+						<a href="#part_2">Part 2</a> relates to support by authoring tools
 						for the creation, by any author (not just those with disabilities),
 						of [=web content=] that is more accessible to [=end users=] with
 						disabilities. Both parts include [=normative=] &quot;Conformance
 						Applicability Notes&quot; that apply to all of the success criteria
 						within that part:
-						<a href="#part_a_applic_notes">
-                            Part A Conformance Applicability Notes</a>
+						<a href="#part_1_applic_notes">
+                            Part 1 Conformance Applicability Notes</a>
 						and
-						<a href="#part_b_applic_notes">
-                            Part B Conformance Applicability Notes</a>.
+						<a href="#part_2_applic_notes">
+                            Part 2 Conformance Applicability Notes</a>.
 					</li>
 					<li>
 						<strong>Principles:</strong> Under each part are several high-level
@@ -262,87 +263,85 @@
 			</section>
 		</section>
 
-		<section id="part_a">
-			<h2>Guidelines Part A: Make the authoring tool user interface accessible</h2>
+		<section id="part_1">
+			<h2>Guidelines Part 1: Make the authoring tool user interface accessible</h2>
 
-			<section id="part_a_applic_notes">
-				<h3>Conformance Applicability Notes</h3>
-				<ol>
-					<li id="part-a-note-1">
-						<strong>
-						Scope of &quot;authoring tool user interface&quot;:</strong>
-						The Part A success criteria apply to all aspects of the [=authoring
-						tool user interface=] that are concerned with producing the
-						<a href="#conformance-technologies">&quot;included&quot; web content 
-                        technologies</a>. This includes [=views=] of the [=web content 
-                        being edited=] and features that are independent of the content 
-                        being edited (e.g. menus, button bars, status bars, user 
-                        preferences, [=documentation=]).
-					</li>
-					<li id="part-a-note-2">
-						<strong>Reflected content accessibility problems:</strong> The
-						[=authoring tool=] is responsible for ensuring that
-						[=editing-views=] display the [=web content being edited=] in a way
-						that is more accessible to [=authors=] with disabilities (e.g.
-						ensuring that <span>[=text alternatives=]</span> in the content can
-						be [=programmatically determined=]). However, where an [=authoring
-						tool user interface accessibility problem=] is caused directly by
-						the content being edited (e.g. if an image in the content lacks a
-						text alternative), then this would not be considered a deficiency in
-						the accessibility of the [=authoring tool user interface=].
-					</li>
-					<li id="part-a-note-3">
-						<strong>Developer control:</strong> The Part A success criteria
-						only apply to the [=authoring tool user interface=] as it is
-						provided by the [=developer=]. They do not apply to any subsequent
-						modifications by parties other than the authoring tool developer
-						(e.g. user modifications of default settings, third-party plug-ins).
-					</li>
-					<li id="part-a-note-4">
-						<strong>User agent features:</strong> [=authoring tool user interface (web-based)|Web-based authoring tools=]
-						may rely on [=user agent=] features (e.g. keyboard navigation, find
-						functions, display preferences, undo features) to satisfy success
-						criteria. <a href="#conformance-claims">Conformance claims</a> are optional,
-						but any claim that is made must
-						<a href="#conf-user-agents">record the user agent(s)</a>.
-					</li>
-					<li id="part-a-note-5">
-						<strong>Accessibility of features provided to meet Part A:</strong>
-						The Part A success criteria apply to the entire [=authoring tool
-						user interface=], including any features added to meet the success
-						criteria in Part A (e.g. documentation, search functions). The only
-						exemption is for [=preview=] features, as long as they meet the
-						relevant success criteria in <a href="#part-a-principle-a.3.7">Guideline A.3.7</a>.
-						Previews are treated differently than editing-views because all
-						authors, including those with disabilities, benefit when preview
-						features accurately reflect the functionality of user agents that
-						are actually in use by <span>[=end users=]</span>.
-					</li>
-					<li id="part-a-note-6">
-						<strong>Unrecognizable content:</strong>
-						When success criteria require authoring tools to treat web content
-						according to semantic criteria, the success criteria only apply when
-						these semantics are encoded programmatically (e.g. text describing
-						an image can only be considered a [=text alternatives for non-text
-						content=] when this role is encoded within markup).
-					</li>
-				</ol>
-			</section>
+			<p id="part_1_applic_notes"><strong>Conformance Applicability Notes</strong></p>
+			<ol>
+				<li id="part-1-note-1">
+					<strong>
+					Scope of &quot;authoring tool user interface&quot;:</strong>
+					The Part 1 success criteria apply to all aspects of the [=authoring
+					tool user interface=] that are concerned with producing the
+					<a href="#conformance-technologies">&quot;included&quot; web content 
+                    technologies</a>. This includes [=views=] of the [=web content 
+                    being edited=] and features that are independent of the content 
+                    being edited (e.g. menus, button bars, status bars, user 
+                    preferences, [=documentation=]).
+				</li>
+				<li id="part-1-note-2">
+					<strong>Reflected content accessibility problems:</strong> The
+					[=authoring tool=] is responsible for ensuring that
+					[=editing-views=] display the [=web content being edited=] in a way
+					that is more accessible to [=authors=] with disabilities (e.g.
+					ensuring that <span>[=text alternatives=]</span> in the content can
+					be [=programmatically determined=]). However, where an [=authoring
+					tool user interface accessibility problem=] is caused directly by
+					the content being edited (e.g. if an image in the content lacks a
+					text alternative), then this would not be considered a deficiency in
+					the accessibility of the [=authoring tool user interface=].
+				</li>
+				<li id="part-1-note-3">
+					<strong>Developer control:</strong> The Part 1 success criteria
+					only apply to the [=authoring tool user interface=] as it is
+					provided by the [=developer=]. They do not apply to any subsequent
+					modifications by parties other than the authoring tool developer
+					(e.g. user modifications of default settings, third-party plug-ins).
+				</li>
+				<li id="part-1-note-4">
+					<strong>User agent features:</strong> [=authoring tool user interface (web-based)|Web-based authoring tools=]
+					may rely on [=user agent=] features (e.g. keyboard navigation, find
+					functions, display preferences, undo features) to satisfy success
+					criteria. <a href="#conformance-claims">Conformance claims</a> are optional,
+					but any claim that is made must
+					<a href="#conf-user-agents">record the user agent(s)</a>.
+				</li>
+				<li id="part-1-note-5">
+					<strong>Accessibility of features provided to meet Part 1:</strong>
+					The Part 1 success criteria apply to the entire [=authoring tool
+					user interface=], including any features added to meet the success
+					criteria in Part 1 (e.g. documentation, search functions). The only
+					exemption is for [=preview=] features, as long as they meet the
+					relevant success criteria in <a href="#part-1-principle-a.3.7">Guideline 1.3.7</a>.
+					Previews are treated differently than editing-views because all
+					authors, including those with disabilities, benefit when preview
+					features accurately reflect the functionality of user agents that
+					are actually in use by <span>[=end users=]</span>.
+				</li>
+				<li id="part-1-note-6">
+					<strong>Unrecognizable content:</strong>
+					When success criteria require authoring tools to treat web content
+					according to semantic criteria, the success criteria only apply when
+					these semantics are encoded programmatically (e.g. text describing
+					an image can only be considered a [=text alternatives for non-text
+					content=] when this role is encoded within markup).
+				</li>
+			</ol>
 
-			<section id="part-a-principle-a.1">
+			<section id="part-1-principle-a.1">
 				<h3>
-					Principle A.1: Authoring tool user interfaces follow applicable
+					Principle 1.1: Authoring tool user interfaces follow applicable
 					accessibility guidelines
 				</h3>
 
-				<section id="part-a-principle-a.1.1">
+				<section id="part-1-principle-a.1.1">
 					<h4 id="gl_a11">
-						Guideline A.1.1: (For the authoring tool user interface) Ensure that
+						Guideline 1.1.1: (For the authoring tool user interface) Ensure that
 						web-based functionality is accessible.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a11">
-                        Implementing A.1.1</a>
+                        Implementing 1.1.1</a>
 
 					<p>
 						Rationale: When [=authoring tools=] (or parts of authoring tools)
@@ -351,8 +350,8 @@
 						[=authors=], including those using [=assistive technologies=].
 					</p>
 
-					<section id="part-a-principle-a.1.1.1">
-						<h5 id="sc_a111">A.1.1.1 Web-Based Accessible (WCAG)</h5>
+					<section id="part-1-principle-a.1.1.1">
+						<h5 id="sc_a111">1.1.1.1 Web-Based Accessible (WCAG)</h5>
 
 						<p>
 							If the [=authoring tool=] contains [=web-based user interfaces=],
@@ -367,18 +366,18 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a111">
-							Implementing A.1.1.1</a>
+							Implementing 1.1.1.1</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.1.2">
+				<section id="part-1-principle-a.1.2">
 					<h4 id="gl_a12">
-						Guideline A.1.2: (For the authoring tool user interface) Ensure that
+						Guideline 1.1.2: (For the authoring tool user interface) Ensure that
 						non-web-based functionality is accessible.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a12">
-						Implementing A.1.2</a>
+						Implementing 1.1.2</a>
 
 					<p>
 						Rationale: When [=authoring tools=] (or parts of authoring tools)
@@ -388,8 +387,8 @@
 						including those using [=assistive technologies=].
 					</p>
 
-					<section id="part-a-principle-a.1.2.1">
-						<h5 id="sc_a121">A.1.2.1 Accessibility Guidelines:</h5>
+					<section id="part-1-principle-a.1.2.1">
+						<h5 id="sc_a121">1.1.2.1 Accessibility Guidelines:</h5>
 
 						<p>
 							If the [=authoring tool=] contains [=non-web-based user
@@ -399,7 +398,7 @@
 						
 						<p>(<strong>Level A</strong>)</p>
 
-						<div class="note" title="A.1.2.1 Note">
+						<div class="note" title="1.1.2.1 Note">
 							<p>
 								The (optional)
 								<a href="#conformance-explanation-results">
@@ -410,11 +409,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a121">
-							Implementing A.1.2.1</a>
+							Implementing 1.1.2.1</a>
 					</section>
 
-					<section id="part-a-principle-a.1.2.2">
-						<h5 id="sc_a122">A.1.2.2 Platform Accessibility Services:</h5>
+					<section id="part-1-principle-a.1.2.2">
+						<h5 id="sc_a122">1.1.2.2 Platform Accessibility Services:</h5>
 
 						<p>
 							If the [=authoring tool=] contains [=non-web-based user
@@ -425,7 +424,7 @@
                         
                         <p>(<strong>Level A</strong>)</p>
 
-						<div class="note" title="A.1.2.2 Note">
+						<div class="note" title="1.1.2.2 Note">
 							<p>
 								The (optional)
 								<a href="#conformance-explanation-results"
@@ -436,22 +435,22 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a122">
-							Implementing A.1.2.2</a>
+							Implementing 1.1.2.2</a>
 					</section>
 				</section>
 			</section>
 
-			<section id="part-a-principle-a.2">
-				<h3>Principle A.2: Editing-views are perceivable</h3>
+			<section id="part-1-principle-a.2">
+				<h3>Principle 1.2: Editing-views are perceivable</h3>
 
-				<section id="part-a-principle-a.2.1">
+				<section id="part-1-principle-a.2.1">
 					<h4 id="gl_a21">
-						Guideline A.2.1: (For the authoring tool user interface) Make
+						Guideline 1.2.1: (For the authoring tool user interface) Make
 						alternative content available to authors.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a21">
-						Implementing A.2.1</a>
+						Implementing 1.2.1</a>
 
 					<p>
 						Rationale: Some [=authors=] require access to [=alternative
@@ -459,8 +458,8 @@
 						are editing.
 					</p>
 
-					<section id="part-a-principle-a.2.1.1">
-						<h5 id="sc_a211">A.2.1.1 Text Alternatives for Rendered Non-Text Content:</h5>
+					<section id="part-1-principle-a.2.1.1">
+						<h5 id="sc_a211">1.2.1.1 Text Alternatives for Rendered Non-Text Content:</h5>
 
 						<p>
 							If an [=editing-view=] [=renders=] [=non-text content=], then any
@@ -470,11 +469,11 @@
                         <p>(<strong>Level A</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a211">
-							Implementing A.2.1.1</a>
+							Implementing 1.2.1.1</a>
 					</section>
 
-					<section id="part-a-principle-a.2.1.2">
-						<h5 id="sc_a212">A.2.1.2 Alternatives for Rendered Time-Based Media:</h5>
+					<section id="part-1-principle-a.2.1.2">
+						<h5 id="sc_a212">1.2.1.2 Alternatives for Rendered Time-Based Media:</h5>
 
 						<p>
 							If an [=editing-view=] [=renders=] time-based media, then at least
@@ -497,18 +496,18 @@
 						</ul>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a212">
-							Implementing A.2.1.2</a>
+							Implementing 1.2.1.2</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.2.2">
+				<section id="part-1-principle-a.2.2">
 					<h4 id="gl_a22">
-						Guideline A.2.2: (For the authoring tool user interface) Ensure that
+						Guideline 1.2.2: (For the authoring tool user interface) Ensure that
 						editing-view presentation can be programmatically determined.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a22">
-						Implementing A.2.2</a>
+						Implementing 1.2.2</a>
 
 					<p>
 						Rationale: Some [=authors=] need access to details about the
@@ -518,8 +517,8 @@
 						[=end user=] will experience the [=web content being edited=].
 					</p>
 
-					<section id="part-a-principle-a.2.2.1">
-						<h5 id="sc_a221">A.2.2.1 Editing-View Status Indicators:</h5>
+					<section id="part-1-principle-a.2.2.1">
+						<h5 id="sc_a221">1.2.2.1 Editing-View Status Indicators:</h5>
 
 						<p>
 							If an [=editing-view=] adds status indicators to the
@@ -530,7 +529,7 @@
                         
                         <p>(<strong>Level A</strong>)</p>
 
-						<div class="note" title="A.2.2.1 Note">
+						<div class="note" title="1.2.2.1 Note">
 							<p>
 								Status indicators may indicate errors (e.g. spelling errors),
 								tracked changes, hidden elements, or other information.
@@ -538,11 +537,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a221">
-							Implementing A.2.2.1</a>
+							Implementing 1.2.2.1</a>
 					</section>
 
-					<section id="part-a-principle-a.2.2.2">
-						<h5 id="sc_a222">A.2.2.2 Access to Rendered Text Properties:</h5>
+					<section id="part-1-principle-a.2.2.2">
+						<h5 id="sc_a222">1.2.2.2 Access to Rendered Text Properties:</h5>
 
 						<p>
 							If an [=editing-view=] renders any text formatting [=properties=]
@@ -553,22 +552,22 @@
                         <p>(<strong>Level AA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a222">
-							Implementing A.2.2.2</a>
+							Implementing 1.2.2.2</a>
 					</section>
 				</section>
 			</section>
 
-			<section id="part-a-principle-a.3">
-				<h3>Principle A.3: Editing-views are operable</h3>
+			<section id="part-1-principle-a.3">
+				<h3>Principle 1.3: Editing-views are operable</h3>
 
-				<section id="part-a-principle-a.3.1">
+				<section id="part-1-principle-a.3.1">
 					<h4 id="gl_a31">
-						Guideline A.3.1: (For the authoring tool user interface) Provide
+						Guideline 1.3.1: (For the authoring tool user interface) Provide
 						keyboard access to authoring features.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a31">
-						Implementing A.3.1</a>
+						Implementing 1.3.1</a>
 
 					<p>
 						Rationale: Some [=authors=] with limited mobility or visual
@@ -577,8 +576,8 @@
 						tool=].
 					</p>
 
-					<section id="part-a-principle-a.3.1.1">
-						<h5 id="sc_a311">A.3.1.1 Keyboard Access (Minimum):</h5>
+					<section id="part-1-principle-a.3.1.1">
+						<h5 id="sc_a311">1.3.1.1 Keyboard Access (Minimum):</h5>
 
 						<p>
 							All functionality of the [=authoring tool=] is operable through a
@@ -590,7 +589,7 @@
                         
                         <p>(<strong>Level A</strong>)</p>
 
-						<div class="note" title="A.3.1.1 Notes">
+						<div class="note" title="1.3.1.1 Notes">
 							<ul>
 								<li>
 									<em>Note 1:</em> Keyboard interfaces are programmatic services
@@ -616,11 +615,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a311">
-							Implementing A.3.1.1</a>
+							Implementing 1.3.1.1</a>
 					</section>
 
-					<section id="part-a-principle-a.3.1.2">
-						<h5 id="sc_a312">A.3.1.2 No Keyboard Traps:</h5>
+					<section id="part-1-principle-a.3.1.2">
+						<h5 id="sc_a312">1.3.1.2 No Keyboard Traps:</h5>
 
 						<p>
 							If keyboard focus can be moved to a [=component=] using a
@@ -634,11 +633,11 @@
                         <p>(<strong>Level A</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a312">
-							Implementing A.3.1.2</a>
+							Implementing 1.3.1.2</a>
 					</section>
 
-					<section id="part-a-principle-a.3.1.3">
-						<h5 id="sc_a313">A.3.1.3 Efficient Keyboard Access:</h5>
+					<section id="part-1-principle-a.3.1.3">
+						<h5 id="sc_a313">1.3.1.3 Efficient Keyboard Access:</h5>
 
 						<p>
 							The [=authoring tool user interface=] includes mechanisms to make
@@ -649,11 +648,11 @@
                         <p>(<strong>Level AA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a313">
-							Implementing A.3.1.3</a>
+							Implementing 1.3.1.3</a>
 					</section>
 
-					<section id="part-a-principle-a.3.1.4">
-						<h5 id="sc_a314">A.3.1.4 Keyboard Access (Enhanced):</h5>
+					<section id="part-1-principle-a.3.1.4">
+						<h5 id="sc_a314">1.3.1.4 Keyboard Access (Enhanced):</h5>
 
 						<p>
 							All functionality of the [=authoring tool=] is operable through a
@@ -664,11 +663,11 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a314">
-							Implementing A.3.1.4</a>
+							Implementing 1.3.1.4</a>
 					</section>
 
-					<section id="part-a-principle-a.3.1.5">
-						<h5 id="sc_a315">A.3.1.5 Customize Keyboard Access:</h5>
+					<section id="part-1-principle-a.3.1.5">
+						<h5 id="sc_a315">1.3.1.5 Customize Keyboard Access:</h5>
 
 						<p>
 							If the [=authoring tool=] includes keyboard commands, then those
@@ -678,11 +677,11 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a315">
-							Implementing A.3.1.5</a>
+							Implementing 1.3.1.5</a>
 					</section>
 
-					<section id="part-a-principle-a.3.1.6">
-						<h5 id="sc_a316">A.3.1.6 Present Keyboard Commands:</h5>
+					<section id="part-1-principle-a.3.1.6">
+						<h5 id="sc_a316">1.3.1.6 Present Keyboard Commands:</h5>
 
 						<p>
 							If the [=authoring tool=] includes keyboard commands, then the
@@ -694,18 +693,18 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a316">
-							Implementing A.3.1.6</a>
+							Implementing 1.3.1.6</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.3.2">
+				<section id="part-1-principle-a.3.2">
 					<h4 id="gl_a32">
-						Guideline A.3.2: (For the authoring tool user interface) Provide
+						Guideline 1.3.2: (For the authoring tool user interface) Provide
 						authors with enough time.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a32">
-						Implementing A.3.2</a>
+						Implementing 1.3.2</a>
 
 					<p>
 						Rationale: Some [=authors=] who have difficulty typing, operating
@@ -714,8 +713,8 @@
 						speeds, such as clicking on a moving target.
 					</p>
 
-					<section id="part-a-principle-a.3.2.1">
-						<h5 id="sc_a321">A.3.2.1 Auto-Save (Minimum):</h5>
+					<section id="part-1-principle-a.3.2.1">
+						<h5 id="sc_a321">1.3.2.1 Auto-Save (Minimum):</h5>
 
 						<p>
 							The [=authoring tool=] does not include [=session=] [=time
@@ -726,11 +725,11 @@
                         <p>(<strong>Level A</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a321">
-							Implementing A.3.2.1</a>
+							Implementing 1.3.2.1</a>
 					</section>
 
-					<section id="part-a-principle-a.3.2.2">
-						<h5 id="sc_a322">A.3.2.2 Timing Adjustable:</h5>
+					<section id="part-1-principle-a.3.2.2">
+						<h5 id="sc_a322">1.3.2.2 Timing Adjustable:</h5>
 
 						<p>
 							The [=authoring tool=] does not include [=time limits=] or at
@@ -773,11 +772,11 @@
 						</ul>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a322">
-							Implementing A.3.2.2</a>
+							Implementing 1.3.2.2</a>
 					</section>
 
-					<section id="part-a-principle-a.3.2.3">
-						<h5 id="sc_a323">A.3.2.3 Static Input Components:</h5>
+					<section id="part-1-principle-a.3.2.3">
+						<h5 id="sc_a323">1.3.2.3 Static Input Components:</h5>
 
 						<p>
 							The [=authoring tool=] does not include moving [=user interface
@@ -789,11 +788,11 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a323"
-							>Implementing A.3.2.3</a>
+							>Implementing 1.3.2.3</a>
 					</section>
 
-					<section id="part-a-principle-a.3.2.4">
-						<h5 id="sc_a324">A.3.2.4 Content Edits Saved (Extended):</h5>
+					<section id="part-1-principle-a.3.2.4">
+						<h5 id="sc_a324">1.3.2.4 Content Edits Saved (Extended):</h5>
 
 						<p>
 							The [=authoring tool=] can be set to automatically save [=web
@@ -804,27 +803,27 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a324"
-							>Implementing A.3.2.4</a>
+							>Implementing 1.3.2.4</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.3.3">
+				<section id="part-1-principle-a.3.3">
 					<h4 id="gl_a33">
-						Guideline A.3.3: (For the authoring tool user interface) Help
+						Guideline 1.3.3: (For the authoring tool user interface) Help
 						authors avoid flashing that could cause seizures.
 					</h4>
 
 					<a
 						href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a33"
-						>Implementing A.3.3</a>
+						>Implementing 1.3.3</a>
 
 					<p>
 						Rationale: Flashing can cause seizures in [=authors=] with
 						photosensitive seizure disorder.
 					</p>
 
-					<section id="part-a-principle-a.3.3.1">
-						<h5 id="sc_a331">A.3.3.1 Static View Option:</h5>
+					<section id="part-1-principle-a.3.3.1">
+						<h5 id="sc_a331">1.3.3.1 Static View Option:</h5>
 
 						<p>
 							If an [=editing-view=] can play visual time-based content, then
@@ -836,19 +835,19 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a331"
-							>Implementing A.3.3.1</a>
+							>Implementing 1.3.3.1</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.3.4">
+				<section id="part-1-principle-a.3.4">
 					<h4 id="gl_a34">
-						Guideline A.3.4: (For the authoring tool user interface) Enhance
+						Guideline 1.3.4: (For the authoring tool user interface) Enhance
 						navigation and editing via content structure.
 					</h4>
 
 					<a
 						href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a34"
-						>Implementing A.3.4</a>
+						>Implementing 1.3.4</a>
 
 					<p>
 						Rationale: Some [=authors=] who have difficulty typing or operating
@@ -857,8 +856,8 @@
 						content.
 					</p>
 
-					<section id="part-a-principle-a.3.4.1">
-						<h5 id="sc_a341">A.3.4.1 Navigate By Structure:</h5>
+					<section id="part-1-principle-a.3.4.1">
+						<h5 id="sc_a341">1.3.4.1 Navigate By Structure:</h5>
 
 						<p>
 							If [=editing-views=] expose the [=markup=] [=elements=] in the
@@ -872,11 +871,11 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a341"
-							>Implementing A.3.4.1</a>
+							>Implementing 1.3.4.1</a>
 					</section>
 
-					<section id="part-a-principle-a.3.4.2">
-						<h5 id="sc_a342">A.3.4.2 Navigate by Programmatic Relationships:</h5>
+					<section id="part-1-principle-a.3.4.2">
+						<h5 id="sc_a342">1.3.4.2 Navigate by Programmatic Relationships:</h5>
 
 						<p>
 							If [=editing-views=] allow editing of programmatic
@@ -886,7 +885,7 @@
                         
                         <p>(<strong>Level AAA</strong>)</p>
 
-						<div class="note" title="A.3.4.2 Note">
+						<div class="note" title="1.3.4.2 Note">
 							<p>
 								Note: Depending on the [=web content technology=] and the nature
 								of the [=authoring tool=], relationships may include, but are
@@ -897,19 +896,19 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a342"
-							>Implementing A.3.4.2</a>
+							>Implementing 1.3.4.2</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.3.5">
+				<section id="part-1-principle-a.3.5">
 					<h4 id="gl_a35">
-						Guideline A.3.5: (For the authoring tool user interface) Provide
+						Guideline 1.3.5: (For the authoring tool user interface) Provide
 						text search of the content.
 					</h4>
 
 					<a
 						href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a35"
-						>Implementing A.3.5</a>
+						>Implementing 1.3.5</a>
 
 					<p>
 						Rationale: Some [=authors=] who have difficulty typing or operating
@@ -917,8 +916,8 @@
 						arbitrary points within the [=web content being edited=].
 					</p>
 
-					<section id="part-a-principle-a.3.5.1">
-						<h5 id="sc_a351">A.3.5.1 Text Search:</h5>
+					<section id="part-1-principle-a.3.5.1">
+						<h5 id="sc_a351">1.3.5.1 Text Search:</h5>
 
 						<p>
 							If the authoring tool provides an [=editing-view=] of text-based
@@ -950,19 +949,19 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a351"
-							>Implementing A.3.5.1</a>
+							>Implementing 1.3.5.1</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.3.6">
+				<section id="part-1-principle-a.3.6">
 					<h4 id="gl_a36">
-						Guideline A.3.6: (For the authoring tool user interface) Manage
+						Guideline 1.3.6: (For the authoring tool user interface) Manage
 						preference settings.
 					</h4>
 
 					<a
 						href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a36"
-						>Implementing A.3.6</a>
+						>Implementing 1.3.6</a>
 
 					<p>
 						Rationale: Some [=authors=] need to set their own [=display
@@ -973,8 +972,8 @@
 						(e.g. due to fatigue).
 					</p>
 
-					<section id="part-a-principle-a.3.6.1">
-						<h5 id="sc_a361">A.3.6.1 Independence of Display:</h5>
+					<section id="part-1-principle-a.3.6.1">
+						<h5 id="sc_a361">1.3.6.1 Independence of Display:</h5>
 
 						<p>
 							If the [=authoring tool=] includes [=display settings=] for
@@ -987,11 +986,11 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a361"
-							>Implementing A.3.6.1</a>
+							>Implementing 1.3.6.1</a>
 					</section>
 
-					<section id="part-a-principle-a.3.6.2">
-						<h5 id="sc_a362">A.3.6.2 Save Settings:</h5>
+					<section id="part-1-principle-a.3.6.2">
+						<h5 id="sc_a362">1.3.6.2 Save Settings:</h5>
 
 						<p>
 							If the [=authoring tool=] includes [=display=] and/or [=control
@@ -1003,11 +1002,11 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a362"
-							>Implementing A.3.6.2</a>
+							>Implementing 1.3.6.2</a>
 					</section>
 
-					<section id="part-a-principle-a.3.6.3">
-						<h5 id="sc_a363">A.3.6.3 Apply Platform Settings:</h5>
+					<section id="part-1-principle-a.3.6.3">
+						<h5 id="sc_a363">1.3.6.3 Apply Platform Settings:</h5>
 						<p>
 							The [=authoring tool=] respects changes in [=platform=]
 							[=display=] and [=control settings=], unless [=authors=] select
@@ -1019,18 +1018,18 @@
 
 						<a
 							href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a363"
-							>Implementing A.3.6.3</a>
+							>Implementing 1.3.6.3</a>
 					</section>
 				</section>
 
-				<section id="part-a-principle-a.3.7">
+				<section id="part-1-principle-a.3.7">
 					<h4 id="gl_a37">
-						Guideline A.3.7: (For the authoring tool user interface) Ensure that
+						Guideline 1.3.7: (For the authoring tool user interface) Ensure that
 						previews are at least as accessible as in-market user agents.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a37">
-                        Implementing A.3.7</a>
+                        Implementing 1.3.7</a>
 
 					<p>
 						Rationale: [=Preview=] features are provided by many [=authoring
@@ -1040,8 +1039,8 @@
 						opportunity to check their work.
 					</p>
 
-					<section id="part-a-principle-a.3.7.1">
-						<h5 id="sc_a371">A.3.7.1 Preview (Minimum):</h5>
+					<section id="part-1-principle-a.3.7.1">
+						<h5 id="sc_a371">1.3.7.1 Preview (Minimum):</h5>
 
 						<p>
 							If a [=preview=] is provided, then at least one of the following
@@ -1062,11 +1061,11 @@
 						</ul>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a371">
-                            Implementing A.3.7.1</a>
+                            Implementing 1.3.7.1</a>
 					</section>
 
-					<section id="part-a-principle-a.3.7.2">
-						<h5 id="sc_a372">A.3.7.2 Preview (Enhanced):</h5>
+					<section id="part-1-principle-a.3.7.2">
+						<h5 id="sc_a372">1.3.7.2 Preview (Enhanced):</h5>
 
 						<p>
 							If a [=preview=] is provided, then [=authors=] can specify which
@@ -1076,22 +1075,22 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a372">
-                            Implementing A.3.7.2</a>
+                            Implementing 1.3.7.2</a>
 					</section>
 				</section>
 			</section>
 
-			<section id="part-a-principle-a.4">
-				<h3>Principle A.4: Editing-views are understandable</h3>
+			<section id="part-1-principle-a.4">
+				<h3>Principle 1.4: Editing-views are understandable</h3>
 
-				<section id="part-a-principle-a.4.1">
+				<section id="part-1-principle-a.4.1">
 					<h4 id="gl_a41">
-						Guideline A.4.1: (For the authoring tool user interface) Help
+						Guideline 1.4.1: (For the authoring tool user interface) Help
 						authors avoid and correct mistakes.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a41">
-                        Implementing A.4.1</a>
+                        Implementing 1.4.1</a>
 
 					<p>
 						Rationale: Some [=authors=] with disabilities may be more
@@ -1099,8 +1098,8 @@
 						fine movements and speech recognition system errors.
 					</p>
 
-					<section id="part-a-principle-a.4.1.1">
-						<h5 id="sc_a411">A.4.1.1 Content Changes Reversible (Minimum):</h5>
+					<section id="part-1-principle-a.4.1.1">
+						<h5 id="sc_a411">1.4.1.1 Content Changes Reversible (Minimum):</h5>
 
 						<p>
 							All [=authoring actions=] are either [=reversible=] or the
@@ -1109,11 +1108,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a411">
-                            Implementing A.4.1.1</a>
+                            Implementing 1.4.1.1</a>
 					</section>
 
-					<section id="part-a-principle-a.4.1.2">
-						<h5 id="sc_a412">A.4.1.2 Settings Change Confirmation:</h5>
+					<section id="part-1-principle-a.4.1.2">
+						<h5 id="sc_a412">1.4.1.2 Settings Change Confirmation:</h5>
 
 						<p>
 							If the [=authoring tool=] provides mechanisms for changing
@@ -1123,11 +1122,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a412">
-                            Implementing A.4.1.2</a>
+                            Implementing 1.4.1.2</a>
 					</section>
 
-					<section id="part-a-principle-a.4.1.3">
-						<h5 id="sc_a413">A.4.1.3 Content Changes Reversible (Enhanced):</h5>
+					<section id="part-1-principle-a.4.1.3">
+						<h5 id="sc_a413">1.4.1.3 Content Changes Reversible (Enhanced):</h5>
 
 						<p>
 							[=Authors=] can sequentially reverse a series of [=reversible
@@ -1136,7 +1135,7 @@
                         
                         <p>(<strong>Level AAA</strong>)</p>
 
-						<div class="note" title="A.4.1.3 Note">
+						<div class="note" title="1.4.1.3 Note">
 							<p>
 								It is acceptable to clear the authoring action history at the
 								[=end of authoring sessions=].
@@ -1144,19 +1143,19 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a413">
-                            Implementing A.4.1.3</a>
+                            Implementing 1.4.1.3</a>
 					</section>
 				</section>
 
 				<section id="guidelines-interface-accessible-principle-4-2">
 					<h4 id="gl_a42">
-						Guideline A.4.2: (For the authoring tool user interface) Document
+						Guideline 1.4.2: (For the authoring tool user interface) Document
 						the user interface, including all accessibility features.
 					</h4>
 
 					<a
 						href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_a42"
-						>Implementing A.4.2</a
+						>Implementing 1.4.2</a
 					>
 
 					<p>
@@ -1164,12 +1163,12 @@
 						the [=authoring tool user interface=] without [=documentation=].
 					</p>
 
-					<section id="part-a-principle-a.4.2.1">
-						<h5 id="sc_a421">A.4.2.1 Describe Accessibility Features:</h5>
+					<section id="part-1-principle-a.4.2.1">
+						<h5 id="sc_a421">1.4.2.1 Describe Accessibility Features:</h5>
 
 						<p>
 							For each [=authoring tool=] feature that is used to meet
-							<a href="#part_a">Part A</a> of ATAG 2.0, at least one of the
+							<a href="#part_1">Part 1</a> of ATAG 2.0, at least one of the
 							following is true:
 						</p>
                         
@@ -1200,17 +1199,17 @@
 						<div class="note">
 							<p>
 								The accessibility of the documentation is covered by
-								<a href="#part-a-principle-a.1.1">Guideline A.1.1</a> and
-								<a href="#part-a-principle-a.1.2">Guideline A.1.2</a>.
+								<a href="#part-1-principle-a.1.1">Guideline 1.1.1</a> and
+								<a href="#part-1-principle-a.1.2">Guideline 1.1.2</a>.
 							</p>
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a421">
-                            Implementing A.4.2.1</a>
+                            Implementing 1.4.2.1</a>
 					</section>
 
-					<section id="part-a-principle-a.4.2.2">
-						<h5 id="sc_a422">A.4.2.2 Document All Features:</h5>
+					<section id="part-1-principle-a.4.2.2">
+						<h5 id="sc_a422">1.4.2.2 Document All Features:</h5>
 
 						<p>
 							For each [=authoring tool=] feature, at least one of the following
@@ -1241,106 +1240,104 @@
 							</li>
 						</ul>
 
-						<div class="note" title="A.4.2.2 Note">
+						<div class="note" title="1.4.2.2 Note">
 							<p>
 								The accessibility of the documentation is covered by
-								<a href="#part-a-principle-a.1.1">Guideline A.1.1</a> and
-								<a href="#part-a-principle-a.1.2">Guideline A.1.2</a>.
+								<a href="#part-1-principle-a.1.1">Guideline 1.1.1</a> and
+								<a href="#part-1-principle-a.1.2">Guideline 1.1.2</a>.
 							</p>
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_a422">
-                            Implementing A.4.2.2</a>
+                            Implementing 1.4.2.2</a>
 					</section>
 				</section>
 			</section>
         </section>
 
-        <section id="part_b">
-			<h2>Guidelines Part B: Support the production of accessible content</h2>
+        <section id="part_2">
+			<h2>Guidelines Part 2: Support the production of accessible content</h2>
 
-			<section id="part_b_applic_notes">
-				<h3>Part B Conformance Applicability Notes:</h3>
+			<p id="part_2_applic_notes">Part 2 Conformance Applicability Notes:</p>
 
-				<ol>
-					<li id="part-b-note-1">
-						<strong>Author availability:</strong> Any Part B success criteria
-						that refer to [=authors=] only apply during [=authoring sessions=].
-					</li>
-					<li id="part-b-note-2">
-						<strong>Developer control:</strong>
-						The Part B success criteria only apply to the [=authoring tool=] as
-						it is provided by the [=developer=]. This does not include
-						subsequent modifications by parties other than the authoring tool
-						developer (e.g. third-party plug-ins, user-defined [=templates=],
-						user modifications of default settings).
-					</li>
-					<li id="part-b-note-3">
-						<strong>Applicability after the end of an authoring session:</strong>
-						[=Authoring tools=] are responsible for the [=web content
-						accessibility (WCAG)=] of [=web content=] that they
-						<span class="sc">[=automatically generate=]</span> after the [=end
-						of an author's authoring session=] (see
-						<a href="#part-b-principle-b.1.1.1">Success Criterion B.1.1.1</a>). For example, if
-						the developer changes the site-wide [=templates=] of a content
-						management system, these would be required to meet the accessibility
-						requirements for automatically-generated content. Authoring tools
-						are not responsible for changes to the accessibility of content that
-						the author causes, whether it is [=author-generated=] or
-						automatically-generated by another system that the author has
-						specified (e.g. a third-party feed).
-					</li>
-					<li id="part-b-note-4">
-						<strong>Authoring systems:</strong>
-						As per the ATAG 2.0 definition of [=authoring tool=], several
-						software tools (identified in any
-						<a href="#conformance-claims">conformance claim</a>) can be used in
-						conjunction to meet the requirements of Part B (e.g. an authoring
-						tool could make use of a third-party software accessibility
-						[=checking=] tool).
-					</li>
-					<li id="part-b-note-5">
-						<strong>Accessibility of features provided to meet Part B:</strong>
-						The <a href="#part_a">Part A</a> success criteria apply to the
-						entire [=authoring tool user interface=], including any features
-						that must be present to meet the success criteria in Part B (e.g.
-						checking tools, repair tools, tutorials, documentation).
-					</li>
-					<li id="part-b-note-6">
-						<strong>Multiple authoring roles:</strong>
-						Some [=authoring tools=] include multiple [=author=] roles, each
-						with different views and content editing [=permissions=] (e.g. a
-						content management system may separate the roles of designers,
-						content authors, and quality assurers). In these cases, the Part B
-						success criteria apply to the authoring tool as a whole, not to the
-						view provided to any particular authoring role. [=Accessible
-						content support features=] should be made available to any authoring
-						role where it would be useful.
-					</li>
-					<li id="part-b-note-7">
-						<strong>Unrecognizable content:</strong>
-						When success criteria require authoring tools to treat web content
-						according to semantic criteria, the success criteria only apply when
-						these semantics are encoded programmatically (e.g. text describing
-						an image can only be considered a [=text alternatives for non-text
-						content=] when this role is encoded within markup).
-					</li>
-				</ol>
-			</section>
+			<ol>
+				<li id="part-2-note-1">
+					<strong>Author availability:</strong> Any Part 2 success criteria
+					that refer to [=authors=] only apply during [=authoring sessions=].
+				</li>
+				<li id="part-2-note-2">
+					<strong>Developer control:</strong>
+					The Part 2 success criteria only apply to the [=authoring tool=] as
+					it is provided by the [=developer=]. This does not include
+					subsequent modifications by parties other than the authoring tool
+					developer (e.g. third-party plug-ins, user-defined [=templates=],
+					user modifications of default settings).
+				</li>
+				<li id="part-2-note-3">
+					<strong>Applicability after the end of an authoring session:</strong>
+					[=Authoring tools=] are responsible for the [=web content
+					accessibility (WCAG)=] of [=web content=] that they
+					<span class="sc">[=automatically generate=]</span> after the [=end
+					of an author's authoring session=] (see
+					<a href="#part-2-principle-2.1.1.1">Success Criterion 2.1.1.1</a>). For example, if
+					the developer changes the site-wide [=templates=] of a content
+					management system, these would be required to meet the accessibility
+					requirements for automatically-generated content. Authoring tools
+					are not responsible for changes to the accessibility of content that
+					the author causes, whether it is [=author-generated=] or
+					automatically-generated by another system that the author has
+					specified (e.g. a third-party feed).
+				</li>
+				<li id="part-2-note-4">
+					<strong>Authoring systems:</strong>
+					As per the ATAG 2.0 definition of [=authoring tool=], several
+					software tools (identified in any
+					<a href="#conformance-claims">conformance claim</a>) can be used in
+					conjunction to meet the requirements of Part 2 (e.g. an authoring
+					tool could make use of a third-party software accessibility
+					[=checking=] tool).
+				</li>
+				<li id="part-2-note-5">
+					<strong>Accessibility of features provided to meet Part 2:</strong>
+					The <a href="#part_1">Part 1</a> success criteria apply to the
+					entire [=authoring tool user interface=], including any features
+					that must be present to meet the success criteria in Part 2 (e.g.
+					checking tools, repair tools, tutorials, documentation).
+				</li>
+				<li id="part-2-note-6">
+					<strong>Multiple authoring roles:</strong>
+					Some [=authoring tools=] include multiple [=author=] roles, each
+					with different views and content editing [=permissions=] (e.g. a
+					content management system may separate the roles of designers,
+					content authors, and quality assurers). In these cases, the Part 2
+					success criteria apply to the authoring tool as a whole, not to the
+					view provided to any particular authoring role. [=Accessible
+					content support features=] should be made available to any authoring
+					role where it would be useful.
+				</li>
+				<li id="part-2-note-7">
+					<strong>Unrecognizable content:</strong>
+					When success criteria require authoring tools to treat web content
+					according to semantic criteria, the success criteria only apply when
+					these semantics are encoded programmatically (e.g. text describing
+					an image can only be considered a [=text alternatives for non-text
+					content=] when this role is encoded within markup).
+				</li>
+			</ol>
 
-			<section id="part-b-principle-b.1">
+			<section id="part-2-principle-2.1">
 				<h3>
-					Principle B.1: Fully automatic processes produce accessible content
+					Principle 2.1: Fully automatic processes produce accessible content
 				</h3>
 
-				<section id="part-b-principle-b.1.1">
+				<section id="part-2-principle-2.1.1">
 					<h4 id="gl_b11">
-						Guideline B.1.1: Ensure that automatically-specified content is
+						Guideline 2.1.1: Ensure that automatically-specified content is
 						accessible.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b11">
-                        Implementing B.1.1</a>
+                        Implementing 2.1.1</a>
 
 					<p>
 						Rationale: If [=authoring tools=]
@@ -1350,9 +1347,9 @@
 						[=repair=] tasks on [=authors=].
 					</p>
 
-					<section id="part-b-principle-b.1.1.1">
+					<section id="part-2-principle-2.1.1.1">
 						<h5 id="sc_b111">
-							B.1.1.1 Content Auto-Generation After Authoring Sessions (WCAG):
+							2.1.1.1 Content Auto-Generation After Authoring Sessions (WCAG):
 						</h5>
 
 						<p>
@@ -1368,7 +1365,7 @@
 							2.0 success criteria)
 						</p>
 
-						<div class="note" title="B.1.1.1 Note">
+						<div class="note" title="2.1.1.1 Note">
 							<p>
 								This success criterion applies only to automatic processes
 								specified by the [=authoring tool developer=]. It does not apply
@@ -1378,12 +1375,12 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b111">
-                            Implementing B.1.1.1</a>
+                            Implementing 2.1.1.1</a>
 					</section>
 
-					<section id="part-b-principle-b.1.1.2">
+					<section id="part-2-principle-2.1.1.2">
 						<h5 id="sc_b112">
-							B.1.1.2 Content Auto-Generation During Authoring Sessions (WCAG):
+							2.1.1.2 Content Auto-Generation During Authoring Sessions (WCAG):
 						</h5>
 
 						<p>
@@ -1423,7 +1420,7 @@
 							</li>
 						</ul>
 
-						<div class="note" title="B.1.1.2 Notes">
+						<div class="note" title="2.1.1.2 Notes">
 							<ul>
 								<li>
 									<em class="note-handle">Note 1:</em> Automatic generation
@@ -1439,17 +1436,17 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b112">
-                            Implementing B.1.1.2</a>
+                            Implementing 2.1.1.2</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.1.2">
+				<section id="part-2-principle-2.1.2">
 					<h4 id="gl_b12">
-						Guideline B.1.2: Ensure that accessibility information is preserved.
+						Guideline 2.1.2: Ensure that accessibility information is preserved.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b12">
-                        Implementing B.1.2</a>
+                        Implementing 2.1.2</a>
 
 					<p>
 						Rationale: [=Accessibility information (WCAG)=] is critical to
@@ -1458,8 +1455,8 @@
 						transformations=].
 					</p>
 
-					<section id="part-b-principle-b.1.2.1">
-						<h5 id="sc_b121">B.1.2.1 Restructuring and Recoding Transformations (WCAG):</h5>
+					<section id="part-2-principle-2.1.2.1">
+						<h5 id="sc_b121">2.1.2.1 Restructuring and Recoding Transformations (WCAG):</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=restructuring
@@ -1498,12 +1495,12 @@
 							</li>
 						</ul>
 
-						<div class="note" title="B.1.2.1 Notes">
+						<div class="note" title="2.1.2.1 Notes">
 							<ul>
 								<li>
 									<em class="note-handle">Note 1:</em> For [=text alternatives
 									for non-text content=], see
-									<a href="#part-b-principle-b.1.2.4">Success Criterion B.1.2.4</a>.
+									<a href="#part-2-principle-2.1.2.4">Success Criterion 2.1.2.4</a>.
 								</li>
 								<li>
 									<em class="note-handle">Note 2:</em> This success criteria
@@ -1515,11 +1512,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b121">
-                            Implementing B.1.2.1</a>
+                            Implementing 2.1.2.1</a>
 					</section>
 
-					<section id="part-b-principle-b.1.2.2">
-						<h5 id="sc_b122">B.1.2.2 Copy-Paste Inside Authoring Tool (WCAG):</h5>
+					<section id="part-2-principle-2.1.2.2">
+						<h5 id="sc_b122">2.1.2.2 Copy-Paste Inside Authoring Tool (WCAG):</h5>
 
 						<p>
 							If the [=authoring tool=] supports copy and paste of [=structured
@@ -1537,11 +1534,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b122">
-                            Implementing B.1.2.2</a>
+                            Implementing 2.1.2.2</a>
 					</section>
 
-					<section id="part-b-principle-b.1.2.3">
-						<h5 id="sc_b123">B.1.2.3 Optimizations Preserve Accessibility:</h5>
+					<section id="part-2-principle-2.1.2.3">
+						<h5 id="sc_b123">2.1.2.3 Optimizations Preserve Accessibility:</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=optimizing web content
@@ -1552,12 +1549,12 @@
                         <p>(<strong>Level A</strong>).</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b123">
-                            Implementing B.1.2.3</a>
+                            Implementing 2.1.2.3</a>
 					</section>
 
-					<section id="part-b-principle-b.1.2.4">
+					<section id="part-2-principle-2.1.2.4">
 						<h5 id="sc_b124">
-							B.1.2.4 Text Alternatives for Non-Text Content are Preserved:
+							2.1.2.4 Text Alternatives for Non-Text Content are Preserved:
 						</h5>
 
 						<p>
@@ -1570,7 +1567,7 @@
                         
                         <p>(<strong>Level A</strong>).</p>
 
-						<div class="note" title="B.1.2.4 Note">
+						<div class="note" title="2.1.2.4 Note">
 							<p>
 								This success criterion only applies when the output technology
 								is <a href="#conformance-technologies">&quot;included&quot;</a> for
@@ -1579,24 +1576,24 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b124">
-                            Implementing B.1.2.4</a>
+                            Implementing 2.1.2.4</a>
 					</section>
 				</section>
 			</section>
 
-			<section id="part-b-principle-b.2">
+			<section id="part-2-principle-2.2">
 				<h3>
-					Principle B.2: Authors are supported in producing accessible content
+					Principle 2.2: Authors are supported in producing accessible content
 				</h3>
 
-				<section id="part-b-principle-b.2.1">
+				<section id="part-2-principle-2.2.1">
 					<h4 id="gl_b21">
-						Guideline B.2.1: Ensure that accessible content production is
+						Guideline 2.2.1: Ensure that accessible content production is
 						possible.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b21">
-                        Implementing B.2.1</a>
+                        Implementing 2.2.1</a>
 
 					<p>
 						Rationale: To support [=accessible web content (WCAG)=] production,
@@ -1604,8 +1601,8 @@
 						with [[WCAG20]] using the [=authoring tool=].
 					</p>
 
-					<section id="part-b-principle-b.2.1.1">
-						<h5 id="sc_b211">B.2.1.1 Accessible Content Possible (WCAG):</h5>
+					<section id="part-2-principle-2.2.1.1">
+						<h5 id="sc_b211">2.2.1.1 Accessible Content Possible (WCAG):</h5>
 
 						<p>
 							The [=authoring tool=] does not place [=restrictions=] on the
@@ -1620,15 +1617,15 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b211">
-                            Implementing B.2.1.1</a>
+                            Implementing 2.2.1.1</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.2.2">
-					<h4 id="gl_b22">Guideline B.2.2: Guide authors to produce accessible content.</h4>
+				<section id="part-2-principle-2.2.2">
+					<h4 id="gl_b22">Guideline 2.2.2: Guide authors to produce accessible content.</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b22">
-                        Implementing B.2.2</a>
+                        Implementing 2.2.2</a>
 
 					<p>
 						Rationale: By guiding [=authors=] from the outset toward the
@@ -1637,8 +1634,8 @@
 						[=repair=] effort is required.
 					</p>
 
-					<section id="part-b-principle-b.2.2.1">
-						<h5 id="sc_b221">B.2.2.1 Accessible Option Prominence (WCAG):</h5>
+					<section id="part-2-principle-2.2.2.1">
+						<h5 id="sc_b221">2.2.2.1 Accessible Option Prominence (WCAG):</h5>
 
 						<p>
 							If [=authors=] are provided with a choice of [=authoring actions=]
@@ -1654,11 +1651,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b221">
-                            Implementing B.2.2.1</a>
+                            Implementing 2.2.2.1</a>
 					</section>
 
-					<section id="part-b-principle-b.2.2.2">
-						<h5 id="sc_b222">B.2.2.2 Setting Accessibility Properties (WCAG):</h5>
+					<section id="part-2-principle-2.2.2.2">
+						<h5 id="sc_b222">2.2.2.2 Setting Accessibility Properties (WCAG):</h5>
 
 						<p>
 							If the authoring tool provides mechanisms to set [=web content
@@ -1673,26 +1670,26 @@
 							2.0 success criteria)
 						</p>
 
-						<div class="note" title="B.2.2.2 Note">
+						<div class="note" title="2.2.2.2 Note">
 							<p>
 								For the prominence of the mechanisms, see
-								<a href="#part-b-principle-b.4.1.4">Success Criterion B.4.1.4</a>.
+								<a href="#part-2-principle-2.4.1.4">Success Criterion 2.4.1.4</a>.
 							</p>
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b222">
-                            Implementing B.2.2.2</a>
+                            Implementing 2.2.2.2</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.2.3">
+				<section id="part-2-principle-2.2.3">
 					<h4 id="gl_b23">
-						Guideline B.2.3: Assist authors with managing alternative content
+						Guideline 2.2.3: Assist authors with managing alternative content
 						for non-text content.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b23">
-                        Implementing B.2.3</a>
+                        Implementing 2.2.3</a>
 
 					<p>
 						Rationale: Improperly generated [=alternative content=] can create
@@ -1700,17 +1697,17 @@
 						accessibility [=checking=].
 					</p>
 
-					<div class="note" title="B.2.3 Note">
+					<div class="note" title="2.2.3 Note">
 						<p>
 							This guideline only applies when [=non-text content=] is specified
 							by [=authors=] (e.g. inserting an image). When non-text content is
 							<span class="sc">[=automatically=]</span> added by the [=authoring
-							tool=], see <a href="#part-b-principle-b.1.1">Guideline B.1.1</a>.
+							tool=], see <a href="#part-2-principle-2.1.1">Guideline 2.1.1</a>.
 						</p>
 					</div>
 
-					<section id="part-b-principle-b.2.3.1">
-						<h5 id="sc_b231">B.2.3.1 Alternative Content is Editable (WCAG):</h5>
+					<section id="part-2-principle-2.2.3.1">
+						<h5 id="sc_b231">2.2.3.1 Alternative Content is Editable (WCAG):</h5>
 
 						<p>
 							If the [=authoring tool=] provides functionality for adding
@@ -1725,7 +1722,7 @@
 							2.0 success criteria)
 						</p>
 
-						<div class="note" title="B.2.3.1 Note">
+						<div class="note" title="2.2.3.1 Note">
 							<p>
 								An exception can be made when the non-text content is known to
 								be decoration, formatting, invisible or a CAPTCHA.
@@ -1733,11 +1730,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b231">
-                            Implementing B.2.3.1</a>
+                            Implementing 2.2.3.1</a>
 					</section>
 
-					<section id="part-b-principle-b.2.3.2">
-						<h5 id="sc_b232">B.2.3.2 Automating Repair of Text Alternatives:</h5>
+					<section id="part-2-principle-2.2.3.2">
+						<h5 id="sc_b232">2.2.3.2 Automating Repair of Text Alternatives:</h5>
 
 						<p>
 							The [=authoring tool=] does not attempt to [=repair=] [=text
@@ -1769,11 +1766,11 @@
 						</ul>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b232">
-							Implementing B.2.3.2</a>
+							Implementing 2.2.3.2</a>
 					</section>
 
-					<section id="part-b-principle-b.2.3.3">
-						<h5 id="sc_b233">B.2.3.3 Save for Reuse:</h5>
+					<section id="part-2-principle-2.2.3.3">
+						<h5 id="sc_b233">2.2.3.3 Save for Reuse:</h5>
 
 						<p>
 							If the [=authoring tool=] provides the functionality for adding
@@ -1796,15 +1793,15 @@
 						</ul>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b233">
-							Implementing B.2.3.3</a>
+							Implementing 2.2.3.3</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.2.4">
-					<h4 id="gl_b24">Guideline B.2.4: Assist authors with accessible templates.</h4>
+				<section id="part-2-principle-2.2.4">
+					<h4 id="gl_b24">Guideline 2.2.4: Assist authors with accessible templates.</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b24">
-                        Implementing B.2.4</a>
+                        Implementing 2.2.4</a>
 
 					<p>
 						Rationale: Providing [=accessible templates (WCAG)=] can have
@@ -1815,8 +1812,8 @@
 						content (WCAG).
 					</p>
 
-					<section id="part-b-principle-b.2.4.1">
-						<h5 id="sc_b241">B.2.4.1 Accessible Template Options (WCAG):</h5>
+					<section id="part-2-principle-2.2.4.1">
+						<h5 id="sc_b241">2.2.4.1 Accessible Template Options (WCAG):</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=templates=], then there are
@@ -1831,11 +1828,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b241">
-                            Implementing B.2.4.1</a>
+                            Implementing 2.2.4.1</a>
 					</section>
 
-					<section id="part-b-principle-b.2.4.2">
-						<h5 id="sc_b242">B.2.4.2 Identify Template Accessibility:</h5>
+					<section id="part-2-principle-2.2.4.2">
+						<h5 id="sc_b242">2.2.4.2 Identify Template Accessibility:</h5>
 
 						<p>
 							If the [=authoring tool=] includes a [=template selection
@@ -1845,7 +1842,7 @@
 						</p>
                         <p>(<strong>Level AA</strong>)</p>
 
-						<div class="note" title="B.2.4.2 Note">
+						<div class="note" title="2.2.4.2 Note">
 							<p>
 								The distinction can involve providing information for the
 								accessible templates, the non-accessible templates or both.
@@ -1853,11 +1850,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b242">
-                            Implementing B.2.4.2</a>
+                            Implementing 2.2.4.2</a>
 					</section>
 
-					<section id="part-b-principle-b2.4.3">
-						<h5 id="sc_b243">B.2.4.3 Author-Created Templates:</h5>
+					<section id="part-2-principle-b2.4.3">
+						<h5 id="sc_b243">2.2.4.3 Author-Created Templates:</h5>
 
 						<p>
 							If the [=authoring tool=] includes a [=template selection
@@ -1877,11 +1874,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b243">
-                            Implementing B.2.4.3</a>
+                            Implementing 2.2.4.3</a>
 					</section>
 
-					<section id="part-b-principle-b.2.4.4">
-						<h5 id="sc_b244">B.2.4.4 Accessible Template Options (Enhanced):</h5>
+					<section id="part-2-principle-2.2.4.4">
+						<h5 id="sc_b244">2.2.4.4 Accessible Template Options (Enhanced):</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=templates=], then all of the
@@ -1891,18 +1888,18 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b244">
-                            Implementing B.2.4.4</a>
+                            Implementing 2.2.4.4</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.2.5">
+				<section id="part-2-principle-2.2.5">
 					<h4 id="gl_b25">
-						Guideline B.2.5: Assist authors with accessible pre-authored
+						Guideline 2.2.5: Assist authors with accessible pre-authored
 						content.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b25">
-                        Implementing B.2.5</a>
+                        Implementing 2.2.5</a>
 
 					<p>
 						Rationale: Providing [=accessible pre-authored content (WCAG)=]
@@ -1913,8 +1910,8 @@
 						demonstrating the importance of accessibility.
 					</p>
 
-					<section id="part-b-principle-b.2.5.1">
-						<h5 id="sc_b251">B.2.5.1 Accessible Pre-Authored Content Options:</h5>
+					<section id="part-2-principle-2.2.5.1">
+						<h5 id="sc_b251">2.2.5.1 Accessible Pre-Authored Content Options:</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=pre-authored content=], then
@@ -1925,11 +1922,11 @@
                         <p>(<strong>Level AA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b251">
-                            Implementing B.2.5.1</a>
+                            Implementing 2.2.5.1</a>
 					</section>
 
-					<section id="part-b-principle-b.2.5.2">
-						<h5 id="sc_b252">B.2.5.2 Identify Pre-Authored Content Accessibility:</h5>
+					<section id="part-2-principle-2.2.5.2">
+						<h5 id="sc_b252">2.2.5.2 Identify Pre-Authored Content Accessibility:</h5>
 
 						<p>
 							If the [=authoring tool=] includes a [=pre-authored content selection mechanism=] and provides any non-[=accessible pre-authored content (WCAG Level AA)=] [=options=], then the
@@ -1948,25 +1945,25 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b252">
-                            Implementing B.2.5.2</a>
+                            Implementing 2.2.5.2</a>
 					</section>
 				</section>
 			</section>
 
-			<section id="part-b-principle-b.3">
+			<section id="part-2-principle-2.3">
 				<h3>
-					Principle B.3: Authors are supported in improving the accessibility of
+					Principle 2.3: Authors are supported in improving the accessibility of
 					existing content
 				</h3>
 
-				<section id="part-b-principle-b.3.1">
+				<section id="part-2-principle-2.3.1">
 					<h4 id="gl_b31">
-						Guideline B.3.1: Assist authors in checking for accessibility
+						Guideline 2.3.1: Assist authors in checking for accessibility
 						problems.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b31">
-                        Implementing B.3.1</a>
+                        Implementing 2.3.1</a>
 
 					<p>
 						Rationale: When [=accessibility checking=] is an integrated function
@@ -1975,8 +1972,8 @@
 						process, so they can be immediately addressed.
 					</p>
 
-					<section id="part-b-principle-b.3.1.1">
-						<h5 id="sc_b311">B.3.1.1 Checking Assistance (WCAG):</h5>
+					<section id="part-2-principle-2.3.1.1">
+						<h5 id="sc_b311">2.3.1.1 Checking Assistance (WCAG):</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=authors=] with the ability to
@@ -1995,7 +1992,7 @@
 							2.0 success criteria)
 						</p>
 
-						<div class="note" title="B.3.1.1 Note">
+						<div class="note" title="2.3.1.1 Note">
 							<p>
 								[=Automated=] and [=semi-automated checking=] is possible (and
 								encouraged) for many types of [=web content accessibility
@@ -2011,11 +2008,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b311">
-                            Implementing B.3.1.1</a>
+                            Implementing 2.3.1.1</a>
 					</section>
 
-					<section id="part-b-principle-b.3.1.2">
-						<h5 id="sc_b312">B.3.1.2 Help Authors Decide:</h5>
+					<section id="part-2-principle-2.3.1.2">
+						<h5 id="sc_b312">2.3.1.2 Help Authors Decide:</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=accessibility checking=] that
@@ -2029,11 +2026,11 @@
                         <p>(<strong>Level A</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b312">
-                            Implementing B.3.1.2</a>
+                            Implementing 2.3.1.2</a>
 					</section>
 
-					<section id="part-b-principle-b.3.1.3">
-						<h5 id="sc_b313">B.3.1.3 Help Authors Locate:</h5>
+					<section id="part-2-principle-2.3.1.3">
+						<h5 id="sc_b313">2.3.1.3 Help Authors Locate:</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=checks=] that require
@@ -2055,11 +2052,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b313">
-                            Implementing B.3.1.3</a>
+                            Implementing 2.3.1.3</a>
 					</section>
 
-					<section id="part-b-principle-b.3.1.4">
-						<h5 id="sc_b314">B.3.1.4 Status Report:</h5>
+					<section id="part-2-principle-2.3.1.4">
+						<h5 id="sc_b314">2.3.1.4 Status Report:</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=checks=], then [=authors=]
@@ -2078,11 +2075,11 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b314">
-							Implementing B.3.1.4</a>
+							Implementing 2.3.1.4</a>
 					</section>
 
-					<section id="part-b-principle-b.3.1.5">
-						<h5 id="sc_b315">B.3.1.5 Programmatic Association of Results:</h5>
+					<section id="part-2-principle-2.3.1.5">
+						<h5 id="sc_b315">2.3.1.5 Programmatic Association of Results:</h5>
 
 						<p>
 							If the [=authoring tool=] provides [=checks=], then the
@@ -2094,17 +2091,17 @@
                         <p>(<strong>Level AA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b315">
-                            Implementing B.3.1.5</a>
+                            Implementing 2.3.1.5</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.3.2">
+				<section id="part-2-principle-2.3.2">
 					<h4 id="gl_b32">
-						Guideline B.3.2: Assist authors in repairing accessibility problems.
+						Guideline 2.3.2: Assist authors in repairing accessibility problems.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b32">
-                        Implementing B.2.3</a>
+                        Implementing 2.2.3</a>
 
 					<p>
 						Rationale: When [=repair=] is an integral part of the authoring
@@ -2113,12 +2110,12 @@
 						(WCAG)=] will be properly addressed.
 					</p>
 
-					<section id="part-b-principle-b.3.2.1">
-						<h5 id="sc_b321">B.3.2.1 Repair Assistance (WCAG):</h5>
+					<section id="part-2-principle-2.3.2.1">
+						<h5 id="sc_b321">2.3.2.1 Repair Assistance (WCAG):</h5>
 
 						<p>
 							If [=checking=] (see
-							<a href="#part-b-principle-b.3.1.1">Success Criterion B.3.1.1</a>) 
+							<a href="#part-2-principle-2.3.1.1">Success Criterion 2.3.1.1</a>) 
                             can detect that a [[WCAG20]] success criterion is not
 							met, then [=repair=] suggestion(s) are provided:
                         </p>
@@ -2146,25 +2143,25 @@
 						</div>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b321">
-                            Implementing B.3.2.1</a>
+                            Implementing 2.3.2.1</a>
 					</section>
 				</section>
 			</section>
 
-			<section id="part-b-principle-b.4">
+			<section id="part-2-principle-2.4">
 				<h3>
-					Principle B.4: Authoring tools promote and integrate their
+					Principle 2.4: Authoring tools promote and integrate their
 					accessibility features
 				</h3>
 
-				<section id="part-b-principle-b.4.1">
+				<section id="part-2-principle-2.4.1">
 					<h4 id="gl_b41">
-						Guideline B.4.1: Ensure the availability of features that support
+						Guideline 2.4.1: Ensure the availability of features that support
 						the production of accessible content.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b41">
-                        Implementing B.4.1</a>
+                        Implementing 2.4.1</a>
 
 					<p>
 						Rationale: The [=accessible content support features=] will be more
@@ -2172,8 +2169,8 @@
 						[=prominence=] within the [=authoring tool user interface=].
 					</p>
 
-					<section id="part-b-principle-b.4.1.1">
-						<h5 id="sc_b411">B.4.1.1 Features Active by Default:</h5>
+					<section id="part-2-principle-2.4.1.1">
+						<h5 id="sc_b411">2.4.1.1 Features Active by Default:</h5>
 
 						<p>
 							All [=accessible content support feature=] are turned on by
@@ -2181,11 +2178,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b411">
-                            Implementing B.4.1.1</a>
+                            Implementing 2.4.1.1</a>
 					</section>
 
-					<section id="part-b-principle-b.4.1.2">
-						<h5 id="sc_b412">B.4.1.2 Option to Reactivate Features:</h5>
+					<section id="part-2-principle-2.4.1.2">
+						<h5 id="sc_b412">2.4.1.2 Option to Reactivate Features:</h5>
 
 						<p>
 							The [=authoring tool=] does not include the
@@ -2197,11 +2194,11 @@
                         <p>(<strong>Level A</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b412">
-                            Implementing B.4.1.2</a>
+                            Implementing 2.4.1.2</a>
 					</section>
 
-					<section id="part-b-principle-b.4.1.3">
-						<h5 id="sc_b413">B.4.1.3 Feature Deactivation Warning:</h5>
+					<section id="part-2-principle-2.4.1.3">
+						<h5 id="sc_b413">2.4.1.3 Feature Deactivation Warning:</h5>
 
 						<p>
 							The [=authoring tool=] does not include the
@@ -2214,11 +2211,11 @@
                         <p>(<strong>Level AA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b413">
-                            Implementing B.4.1.3</a>
+                            Implementing 2.4.1.3</a>
 					</section>
 
-					<section id="part-b-principle-b.4.1.4">
-						<h5 id="sc_b414">B.4.1.4 Feature Prominence:</h5>
+					<section id="part-2-principle-2.4.1.4">
+						<h5 id="sc_b414">2.4.1.4 Feature Prominence:</h5>
 
 						<p>
 							All [=accessible content support features=] are [=at least as
@@ -2229,18 +2226,18 @@
                         <p>(<strong>Level AA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b414">
-                            Implementing B.4.1.4</a>
+                            Implementing 2.4.1.4</a>
 					</section>
 				</section>
 
-				<section id="part-b-principle-b.4.2">
+				<section id="part-2-principle-2.4.2">
 					<h4 id="gl_b42">
-						Guideline B.4.2: Ensure that documentation promotes the production
+						Guideline 2.4.2: Ensure that documentation promotes the production
 						of accessible content.
 					</h4>
 
 					<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#gl_b42">
-                        Implementing B.4.2</a>
+                        Implementing 2.4.2</a>
 
 					<p>
 						Rationale: Some [=authors=] need support in determining how to use
@@ -2252,8 +2249,8 @@
 						accessibility by some authors.
 					</p>
 
-					<section id="part-b-principle-b.4.2.1">
-						<h5 id="sc_b421">B.4.2.1 Model Practice (WCAG):</h5>
+					<section id="part-2-principle-2.4.2.1">
+						<h5 id="sc_b421">2.4.2.1 Model Practice (WCAG):</h5>
 
 						<p>
 							A [=range=] of examples in the [=documentation=] (e.g. [=markup=],
@@ -2268,11 +2265,11 @@
 						</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b421">
-                            Implementing B.4.2.1</a>
+                            Implementing 2.4.2.1</a>
 					</section>
 
-					<section id="part-b-principle-b.4.2.2">
-						<h5 id="sc_b422">B.4.2.2 Feature Instructions:</h5>
+					<section id="part-2-principle-2.4.2.2">
+						<h5 id="sc_b422">2.4.2.2 Feature Instructions:</h5>
 
 						<p>
 							Instructions for using any [=accessible content support
@@ -2282,11 +2279,11 @@
                         <p>(<strong>Level A</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b422">
-                            Implementing B.4.2.2</a>
+                            Implementing 2.4.2.2</a>
 					</section>
 
-					<section id="part-b-principle-b.4.2.3">
-						<h5 id="sc_b423">B.4.2.3 Tutorial:</h5>
+					<section id="part-2-principle-2.4.2.3">
+						<h5 id="sc_b423">2.4.2.3 Tutorial:</h5>
 
 						<p>
 							The [=authoring tool=] provides a [=tutorial=] for an accessible
@@ -2296,11 +2293,11 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b423">
-                            Implementing B.4.2.3</a>
+                            Implementing 2.4.2.3</a>
 					</section>
 
-					<section id="part-b-principle-b.4.2.4">
-						<h5 id="sc_b424">B.4.2.4 Instruction Index:</h5>
+					<section id="part-2-principle-2.4.2.4">
+						<h5 id="sc_b424">2.4.2.4 Instruction Index:</h5>
 
 						<p>
 							The [=authoring tool=] [=documentation=] contains an index to the
@@ -2311,7 +2308,7 @@
                         <p>(<strong>Level AAA</strong>)</p>
 
 						<a href="https://www.w3.org/TR/IMPLEMENTING-ATAG20/#sc_b424">
-                            Implementing B.4.2.4</a>
+                            Implementing 2.4.2.4</a>
 					</section>
 				</section>
 			</section>
@@ -2323,7 +2320,7 @@
 			<p>
 				Conformance means that the [=authoring tool=] satisfies the
 				<a href="#conformance-applicable">applicable</a> success criteria defined in the
-				<a href="#part_a">guidelines</a> section. This conformance section
+				<a href="#part_1">guidelines</a> section. This conformance section
 				describes conformance and lists the conformance requirements.
 			</p>
 
@@ -2379,10 +2376,10 @@
 						Recommendation regarding web content accessibility. For this reason,
 						ATAG 2.0 refers to WCAG 2.0 when setting requirements for (1) the
 						accessibility of [=web-based authoring tool user interfaces=] (in
-						<a href="#part_a">Part A</a>) and (2) how [=authors=] should be
+						<a href="#part_1">Part 1</a>) and (2) how [=authors=] should be
 						enabled, supported, and guided toward producing web content that is
 						more accessible to [=end users=] with disabilities (in
-						<a href="#part_b"> Part B</a>).
+						<a href="#part_2"> Part 2</a>).
 					</p>
 
 					<p>
@@ -2498,10 +2495,10 @@
 
 						<div class="note" title="Conformance Applicability Notes">
 							<p>
-								The <a href="#part_a_applic_notes">
-                                Part A Conformance Applicability Notes</a>
-								and <a href="#part_b_applic_notes">
-        						Part B Conformance Applicability Notes</a>
+								The <a href="#part_1_applic_notes">
+                                Part 1 Conformance Applicability Notes</a>
+								and <a href="#part_2_applic_notes">
+        						Part 2 Conformance Applicability Notes</a>
 								must be applied.
 							</p>
 							<p>
@@ -2545,10 +2542,10 @@
 							</p>
 
 							<p>
-								The <a href="#part_a_applic_notes">
-                                Part A Conformance Applicability Notes</a>
-								and <a href="#part_b_applic_notes">
-                                Part B Conformance Applicability Notes</a>
+								The <a href="#part_1_applic_notes">
+                                Part 1 Conformance Applicability Notes</a>
+								and <a href="#part_2_applic_notes">
+                                Part 2 Conformance Applicability Notes</a>
 								must be applied.
 							</p>
 						</div>
@@ -2599,7 +2596,7 @@
 						ATAG 2.0 may be applied to authoring tools with workflows that
 						involve live authoring of web content (e.g. some collaborative
 						tools). Due to the challenges inherent in real-time publishing,
-						conformance to <a href="#part_b">Part B</a> of ATAG 2.0 for these
+						conformance to <a href="#part_2">Part 2</a> of ATAG 2.0 for these
 						authoring tools may involve some combination of support before
 						(e.g. support in preparing accessible slides), during (e.g. live
 						captioning as WCAG 2.0 requires at Level AA) and after the live
@@ -2760,7 +2757,7 @@
 							<li>
 								<dfn>authoring tool user interface accessibility problems</dfn>
 								Aspects of an [=authoring tool user interface=] that does not
-								meet a success criterion in <a href="#part_a">Part A</a> of ATAG
+								meet a success criterion in <a href="#part_1">Part 1</a> of ATAG
 								2.0.
 							</li>
 							<li>
@@ -2795,7 +2792,7 @@
 						Any features of an [=authoring tool=] that directly support
 						[=authors=] in increasing the accessibility of the [=web
 						content being edited=]. These are features that must be present to
-						meet the success criteria in <a href="#part_b">Part B</a> of ATAG
+						meet the success criteria in <a href="#part_2">Part 2</a> of ATAG
 						2.0.
 					</dd>
 
@@ -2931,7 +2928,7 @@
 						People who use [=authoring tools=] to create or modify [=web
 						content=]. The term may cover roles such as content authors,
 						designers, programmers, publishers, testers, etc. (see
-						<a href="#part-b-note-6">Part B Conformance Applicability 
+						<a href="#part-2-note-6">Part 2 Conformance Applicability 
                             Note 6: Multiple authoring roles</a>). Some authoring 
                         tools control who may be an author by managing
 						[=author permissions=].
@@ -3139,7 +3136,7 @@
 							<li>
 								<dfn class="lint-ignore">accessible authoring tool user interfaces:</dfn> <!-- TODO ATAG: Remove lint-ignore if this definition is used -->
 								Authoring tool user interfaces that meet the success criteria of
-								a level in <a href="#part_a">Part A</a> of ATAG 2.0.
+								a level in <a href="#part_1">Part 1</a> of ATAG 2.0.
 							</li>
 						</ul>
 					</dd>
@@ -3637,9 +3634,9 @@
 						clip art, sample videos, user interface widgets.<br />
 						<em>Note 1:</em> For [=templates=], an incomplete form of
 						pre-authored content, see
-						<a href="#part-b-principle-b.2.4">Guideline B.2.4</a>.<br />
+						<a href="#part-2-principle-2.2.4">Guideline 2.2.4</a>.<br />
 						<em>Note 2:</em> If the authoring tool uses pre-authored content
-						automatically, see <a href="#part-b-principle-b.1.1">Guideline B.1.1</a>.
+						automatically, see <a href="#part-2-principle-2.1.1">Guideline 2.1.1</a>.
 						<ul>
 							<li>
 								<dfn data-lt="accessible pre-authored content (WCAG):|accessible pre-authored content (WCAG)|accessible pre-authored content (to WCAG Level AA)|accessible pre-authored content (WCAG Level AA)">accessible pre-authored content (WCAG):</dfn>
@@ -4050,7 +4047,7 @@
 
 				<p>
 					For the <strong>latest version</strong> of any
-					<acronym title="the World Wide Web Consortium">W3C</acronym> standards
+					<abbr title="the World Wide Web Consortium">W3C</abbr> standards
 					please consult the list of
 					<a href="https://www.w3.org/TR/">W3C Technical Reports</a> at
 					http://www.w3.org/TR/. Some documents listed below may have been


### PR DESCRIPTION
As discussed in issue #22, this is an experiment to see whether it is possible to get the section numbers to match with respec. To make this change even more coherent, I also renamed Part A and Part B to "1" and "2" respectively. 

The only remaining nit is that the numbers are repeated in the titles, which can be adjusted by removing the numbers from the title text, or looking at tricks like the JS one used in WCAG (will need to ask that team how they did it though). 